### PR TITLE
fix: do not override `laststatus=3` set by user

### DIFF
--- a/lua/mini/statusline.lua
+++ b/lua/mini/statusline.lua
@@ -170,8 +170,8 @@ MiniStatusline.config = {
 
   -- Whether to set Vim's settings for statusline (make it always shown with
   -- 'laststatus' set to 2).
-  -- To use global statusline, set this to `false` and 'laststatus' to 3.
-  set_vim_settings = true,
+  -- To use global statusline, set the 'laststatus' to 3.
+  set_vim_settings = vim.o.laststatus == 3 and false or true,
 }
 --minidoc_afterlines_end
 


### PR DESCRIPTION
Hey, thanks for this plugin!

I've recently tried to use the `laststatus=3` in my nvim config. However, overtime I found that after reloading the nvim my `laststatus` becomes overwritten by the `mini.statusline` plugin. 

It took me a bit to figure out where does the issue come from. So I think the UX can be improved here by preventing a silent override of the `laststatus=3` set by user.

WDYT? 